### PR TITLE
Fix CLI output handling and defer NCBI initialization

### DIFF
--- a/src/ContigNet/VirusCNN_siamese.py
+++ b/src/ContigNet/VirusCNN_siamese.py
@@ -1,7 +1,8 @@
+import itertools
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import itertools
 
 
 class VirusCNN(nn.Module):

--- a/src/ContigNet/__main__.py
+++ b/src/ContigNet/__main__.py
@@ -94,7 +94,14 @@ def main(host_dir, virus_dir, output, cpu, show_preview):
     console.print(f"[cyan]→[/cyan] Found {len(virus_list)} virus contig(s)")
     console.print(f"[cyan]→[/cyan] Processing {len(host_list) * len(virus_list)} pair(s)")
 
-    result_df = pd.DataFrame(np.zeros((len(host_list), len(virus_list))), columns=virus_name_list, index=host_name_list)
+    result_df = pd.DataFrame(
+        np.zeros((len(host_list), len(virus_list))),
+        columns=virus_name_list,
+        index=host_name_list,
+    )
+
+    # Preserve the CLI output path before we start computing prediction scores
+    output_path = output
 
     # Process predictions
     with torch.no_grad():
@@ -127,9 +134,18 @@ def main(host_dir, virus_dir, output, cpu, show_preview):
                         host_tensor = torch.Tensor(host_onehot).to(device)[None, None, :, :]
                         virus_tensor = torch.Tensor(virus_onehot).to(device)[None, None, :, :]
                         if str(device) != "cpu":
-                            output = torch.sigmoid(model(host_tensor, virus_tensor)).cpu().numpy().flatten()[0]
+                            score = (
+                                torch.sigmoid(model(host_tensor, virus_tensor))
+                                .cpu()
+                                .numpy()
+                                .flatten()[0]
+                            )
                         else:
-                            output = torch.sigmoid(model(host_tensor, virus_tensor)).numpy().flatten()[0]
+                            score = (
+                                torch.sigmoid(model(host_tensor, virus_tensor))
+                                .numpy()
+                                .flatten()[0]
+                            )
                     except RuntimeError as e:  # Fallback in case of out of GPU memory
                         if "CUDA error: out of memory" in str(e):
                             console.print("[yellow]⚠[/yellow] GPU out of memory, falling back to CPU")
@@ -137,19 +153,23 @@ def main(host_dir, virus_dir, output, cpu, show_preview):
                             model = model.to("cpu")
                             host_tensor = torch.Tensor(host_onehot)[None, None, :, :]
                             virus_tensor = torch.Tensor(virus_onehot)[None, None, :, :]
-                            output = torch.sigmoid(model(host_tensor, virus_tensor)).numpy().flatten()[0]
+                            score = (
+                                torch.sigmoid(model(host_tensor, virus_tensor))
+                                .numpy()
+                                .flatten()[0]
+                            )
                         else:
                             raise e
                     # Convert numpy scalar to Python float for pandas compatibility
-                    result_df.loc[host_name, virus_name] = float(output)
+                    result_df.loc[host_name, virus_name] = float(score)
                     progress.update(virus_task, advance=1)
 
                 progress.remove_task(virus_task)
                 progress.update(host_task, advance=1)
 
     # Save results
-    result_df.to_csv(output)
-    console.print(f"[green]✓[/green] Results saved to: [bold]{output}[/bold]")
+    result_df.to_csv(output_path)
+    console.print(f"[green]✓[/green] Results saved to: [bold]{output_path}[/bold]")
 
     # Show preview if requested
     if show_preview:

--- a/src/ContigNet/__main__.py
+++ b/src/ContigNet/__main__.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python
 
 import os
-import pandas as pd
-import warnings
-import numpy as np
-import torch
-from . import util, VirusCNN_siamese
 import pkgutil
+import warnings
 from io import BytesIO
+
 import click
-from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, TimeRemainingColumn
-from rich.table import Table
-from rich.panel import Panel
+import numpy as np
+import pandas as pd
+import torch
 from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
+from rich.table import Table
+
+from . import VirusCNN_siamese, util
 
 console = Console()
 
@@ -118,14 +120,14 @@ def main(host_dir, virus_dir, output, cpu, show_preview):
 
             host_task = progress.add_task("[cyan]Processing hosts...", total=len(host_list))
 
-            for i, host_fn in enumerate(host_list):
+            for i, _host_fn in enumerate(host_list):
                 host_name = host_name_list[i]
                 host_path = host_path_list[i]
                 host_onehot = util.fasta2onehot(host_path)
 
                 virus_task = progress.add_task(f"[magenta]  → {host_name[:20]}...", total=len(virus_list))
 
-                for j, virus_fn in enumerate(virus_list):
+                for j, _virus_fn in enumerate(virus_list):
                     virus_name = virus_name_list[j]
                     virus_path = virus_path_list[j]
                     virus_onehot = util.fasta2onehot(virus_path)

--- a/src/ContigNet/__main__.py
+++ b/src/ContigNet/__main__.py
@@ -78,7 +78,10 @@ def main(host_dir, virus_dir, output, cpu, show_preview):
     # Load model
     with console.status("[bold green]Loading model...", spinner="dots"):
         model = VirusCNN_siamese.VirusCNN(share_weight=True).to(device)
-        model.load_state_dict(torch.load(BytesIO(pkgutil.get_data("ContigNet", "models/model.dict")), map_location=device))
+        model_bytes = pkgutil.get_data("ContigNet", "models/model.dict")
+        if model_bytes is None:
+            raise FileNotFoundError("Embedded model weights could not be found")
+        model.load_state_dict(torch.load(BytesIO(model_bytes), map_location=device))
     console.print("[green]✓[/green] Model loaded successfully")
 
     # Load file lists

--- a/src/ContigNet/util.py
+++ b/src/ContigNet/util.py
@@ -4,11 +4,12 @@ import pickle
 from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import numpy as np
 from Bio import SeqIO
 from ete3 import NCBITaxa
+from numpy.typing import NDArray
 
 _ncbi: Optional[NCBITaxa] = None
 
@@ -169,7 +170,7 @@ def remove_plasmid_seq(input_dir_path, output_dir_path):
     def filter_fun(fn: str):
         return fn.endswith(".fa") or fn.endswith(".fasta") or fn.endswith(".fna")
 
-    fasta_filename_list = filter(filter_fun, fasta_filename_list)
+    fasta_filename_list = list(filter(filter_fun, fasta_filename_list))
     for fasta_file in fasta_filename_list:
         input_fasta_path = os.path.join(input_dir_path, fasta_file)
         input_handle = open(input_fasta_path)
@@ -256,7 +257,7 @@ def seq2intseq(seq: str, contig_length: Optional[int] = None) -> np.ndarray:
         return np.array(list(map(nt2index, str(seq))))
 
 
-def int2onehot(array: np.ndarray) -> np.ndarray:
+def int2onehot(array: NDArray[np.integer[Any]]) -> NDArray[np.float64]:
     """
     Convert an integer array to one-hot encoded array.
 
@@ -282,10 +283,10 @@ def int2onehot(array: np.ndarray) -> np.ndarray:
     """
     # n = np.max(array) + 1
     n = 4
-    return np.eye(int(n))[array.astype(int)]
+    return cast(NDArray[np.float64], np.eye(int(n), dtype=float)[array.astype(int)])
 
 
-def seq2onehot(seq: str, contig_length: Optional[int] = None) -> np.ndarray:
+def seq2onehot(seq: str, contig_length: Optional[int] = None) -> NDArray[np.float64]:
     """
     Convert a DNA sequence string to a one-hot encoded array.
 
@@ -318,7 +319,7 @@ def seq2onehot(seq: str, contig_length: Optional[int] = None) -> np.ndarray:
     return onehot
 
 
-def fasta2onehot(path: str, contig_length: Optional[int] = None) -> np.ndarray:
+def fasta2onehot(path: str, contig_length: Optional[int] = None) -> NDArray[np.float64]:
     """
     Convert a multi-sequence fasta file to a one-hot encoded array.
 
@@ -350,8 +351,8 @@ def fasta2onehot(path: str, contig_length: Optional[int] = None) -> np.ndarray:
            [0., 0., 0., 1.]])
 
     """
-    seq = [str(s.seq) for s in SeqIO.parse(path, "fasta")]
-    seq = "".join(seq)
+    seq_list = [str(s.seq) for s in SeqIO.parse(path, "fasta")]
+    seq = "".join(seq_list)
     return seq2onehot(seq, contig_length)
 
 

--- a/src/ContigNet/util.py
+++ b/src/ContigNet/util.py
@@ -1,15 +1,14 @@
+import math
+import os
+import pickle
 from itertools import groupby
 from operator import itemgetter
-import os
-import numpy as np
-import pickle
-from typing import Optional, Any
-import pandas as pd
-from ete3 import NCBITaxa
-from Bio import SeqIO
-import math
-from io import StringIO
 from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+from Bio import SeqIO
+from ete3 import NCBITaxa
 
 _ncbi: Optional[NCBITaxa] = None
 
@@ -422,7 +421,7 @@ def tuple_list_to_dict_set(list):
     If multiple tuples have the same first element, the second elements are
     added to the same set for that key.
     """
-    return dict((k, set([v[1] for v in itr])) for k, itr in groupby(list, itemgetter(0)))
+    return {k: {v[1] for v in itr} for k, itr in groupby(list, itemgetter(0))}
 
 
 def load_virus_onehot(virus_dir, virus_list):

--- a/src/ContigNet/util.py
+++ b/src/ContigNet/util.py
@@ -11,7 +11,40 @@ import math
 from io import StringIO
 from pathlib import Path
 
-ncbi = NCBITaxa()
+_ncbi: Optional[NCBITaxa] = None
+
+
+def get_ncbi_taxa() -> NCBITaxa:
+    """Lazily initialize and return a shared ``NCBITaxa`` instance.
+
+    The :mod:`ete3` ``NCBITaxa`` helper downloads taxonomy data the first
+    time it is instantiated, which fails in restricted or offline
+    environments (e.g., continuous integration).  To avoid triggering the
+    download unless taxonomy utilities are explicitly used, the instance is
+    created on demand.
+
+    Returns
+    -------
+    NCBITaxa
+        A cached ``NCBITaxa`` instance ready for use.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``NCBITaxa`` database cannot be initialized.  The original
+        exception is chained for easier debugging.
+    """
+
+    global _ncbi
+    if _ncbi is None:
+        try:
+            _ncbi = NCBITaxa()
+        except Exception as exc:  # pragma: no cover - depends on network availability
+            raise RuntimeError(
+                "Unable to initialize the NCBI taxonomy database. "
+                "Ensure the database is available or run in an environment with network access."
+            ) from exc
+    return _ncbi
 NT_DICT = {"A": 0, "C": 1, "G": 2, "T": 3}
 
 
@@ -348,6 +381,7 @@ def get_rank(taxid, rank):
     >>> get_rank(67890, 'genus')
     9876
     """
+    ncbi = get_ncbi_taxa()
     lineage = ncbi.get_lineage(taxid)
     ranks = ncbi.get_rank(lineage)
     ranks = {ranks[key]: key for key in ranks.keys()}

--- a/tests/test_ContigNet.py
+++ b/tests/test_ContigNet.py
@@ -1,7 +1,9 @@
 import os
 import sys
-import ContigNet
+
 from click.testing import CliRunner
+
+import ContigNet
 from ContigNet.__main__ import main
 
 __all__ = ['ContigNet',]


### PR DESCRIPTION
## Summary
- prevent the ContigNet CLI from overwriting the output path with prediction scores before saving results
- lazily initialize the `NCBITaxa` helper so that running the CLI or tests no longer triggers a network download unless taxonomy utilities are invoked

## Testing
- `uv run pytest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b7c817288325987b3db6b03493f3)